### PR TITLE
Add deduplication keys

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -52,6 +52,10 @@ export interface Completion {
   section?: string | CompletionSection
   /// Can be used to alter the change created when the completion is applied
   extend?: ExtendCompletion
+  /// If multiple sources return the same result, use this field to specifiy a
+  /// deduplication key as well as a priority. For each unique key, only the
+  /// completion with the highest priority will be shown.
+  deduplicate?: { key: string, priority: number }
 }
 
 /// The type returned from

--- a/src/state.ts
+++ b/src/state.ts
@@ -68,7 +68,23 @@ function sortOptions(active: readonly ActiveSource[], state: EditorState) {
     else if (opt.completion.info) result[result.length - 1] = opt
     prev = opt.completion
   }
-  return result
+  // overleaf: Deduplicate results with dedup options
+  const topPriorities = new Map<string, number>()
+  for (const opt of result) {
+    const key = opt.completion.deduplicate?.key
+    if (!key) continue
+    const currentPriority = topPriorities.get(key)
+    if (currentPriority === undefined) {
+      topPriorities.set(key, opt.completion.deduplicate.priority)
+    } else {
+      if (currentPriority < opt.completion.deduplicate.priority) {
+        topPriorities.set(key, opt.completion.deduplicate.priority)
+      }
+    }
+  }
+  return result.filter(opt => opt.completion.deduplicate
+      ? topPriorities.get(opt.completion.deduplicate.key) === opt.completion.deduplicate.priority
+      : true)
 }
 
 class CompletionDialog {


### PR DESCRIPTION
Adds a new deduplication key and priority to `Completion`s. Once all the completions have been fetched, only the completions with the highest priority will be shown.

With asynchronous sources this means that as higher priority results are coming in, they will replace already existing options of lesser priority.