### PR TITLE
Upgrade to codemirror/autocomplete 6.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.16.0 (2024-04-12)
+
+### New features
+
+The new `activateOnCompletion` option allows autocompletion to be configured to chain completion activation for some types of completions.
+
 ## 6.15.0 (2024-03-13)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.14.0 (2024-03-10)
+
+### New features
+
+Completion results can now define a `map` method that can be used to adjust position-dependent information for document changes.
+
 ## 6.13.0 (2024-02-29)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.16.3 (2024-06-19)
+
+### Bug fixes
+
+Avoid adding an `aria-autocomplete` attribute to the editor when there are no active sources active.
+
 ## 6.16.2 (2024-05-31)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.13.0 (2024-02-29)
+
+### New features
+
+Completions may now provide 'commit characters' that, when typed, commit the completion before inserting the character.
+
 ## 6.12.0 (2024-01-12)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.16.2 (2024-05-31)
+
+### Bug fixes
+
+Allow backslash-escaped closing braces inside snippet field names/content.
+
 ## 6.16.1 (2024-05-29)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.16.1 (2024-05-29)
+
+### Bug fixes
+
+Fix a bug where multiple backslashes before a brace in a snippet were all removed.
+
 ## 6.16.0 (2024-04-12)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.18.0 (2024-08-05)
+
+### Bug fixes
+
+Style the info element so that newlines are preserved, to make it easier to display multi-line info from a string source.
+
+### New features
+
+When registering an `abort` handler for a completion query, you can now use the `onDocChange` option to indicate that your query should be aborted as soon as the document changes while it is running.
+
 ## 6.17.0 (2024-07-03)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.17.0 (2024-07-03)
+
+### Bug fixes
+
+Fix an issue where completions weren't properly reset when starting a new completion through `activateOnCompletion`.
+
+### New features
+
+`CompletionContext` objects now have a `view` property that holds the editor view when the query context has a view available.
+
 ## 6.16.3 (2024-06-19)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.15.0 (2024-03-13)
+
+### New features
+
+The new `filterStrict` option can be used to turn off fuzzy matching of completions.
+
 ## 6.14.0 (2024-03-10)
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.15.0",
+  "version": "6.16.0",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.16.3",
+  "version": "6.17.0",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.16.0",
+  "version": "6.16.1",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.12.0",
+  "version": "6.13.0",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.16.1",
+  "version": "6.16.2",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.13.0",
+  "version": "6.14.0",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/autocomplete",
-  "version": "6.16.2",
+  "version": "6.16.3",
   "description": "Autocompletion for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",

--- a/src/closebrackets.ts
+++ b/src/closebrackets.ts
@@ -11,7 +11,7 @@ import {syntaxTree} from "@codemirror/language"
 export interface CloseBracketConfig {
   /// The opening brackets to close. Defaults to `["(", "[", "{", "'",
   /// '"']`. Brackets may be single characters or a triple of quotes
-  /// (as in `"''''"`).
+  /// (as in `"'''"`).
   brackets?: string[]
   /// Characters in front of which newly opened brackets are
   /// automatically closed. Closing always happens in front of

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -83,6 +83,8 @@ export interface CompletionSection {
 export class CompletionContext {
   /// @internal
   abortListeners: (() => void)[] | null = []
+  /// @internal
+  abortOnDocChange = false
 
   /// Create a new completion context. (Mostly useful for testing
   /// completion sources—in the editor, the extension will create
@@ -132,8 +134,19 @@ export class CompletionContext {
   /// Allows you to register abort handlers, which will be called when
   /// the query is
   /// [aborted](#autocomplete.CompletionContext.aborted).
-  addEventListener(type: "abort", listener: () => void) {
-    if (type == "abort" && this.abortListeners) this.abortListeners.push(listener)
+  ///
+  /// By default, running queries will not be aborted for regular
+  /// typing or backspacing, on the assumption that they are likely to
+  /// return a result with a
+  /// [`validFor`](#autocomplete.CompletionResult.validFor) field that
+  /// allows the result to be used after all. Passing `onDocChange:
+  /// true` will cause this query to be aborted for any document
+  /// change.
+  addEventListener(type: "abort", listener: () => void, options?: {onDocChange: boolean}) {
+    if (type == "abort" && this.abortListeners) {
+      this.abortListeners.push(listener)
+      if (options && options.onDocChange) this.abortOnDocChange = true
+    }
   }
 }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -39,6 +39,9 @@ export interface Completion {
   ///
   /// Multiple types can be provided by separating them with spaces.
   type?: string
+  /// When this option is selected, and one of these characters is
+  /// typed, insert the completion before typing the character.
+  commitCharacters?: readonly string[],
   /// When given, should be a number from -99 to 99 that adjusts how
   /// this completion is ranked compared to other completions that
   /// match the input as well as this one. A negative number moves it
@@ -229,6 +232,10 @@ export interface CompletionResult {
   /// [`validFor`](#autocomplete.CompletionResult.validFor)) that the
   /// completion still applies in the new state.
   update?: (current: CompletionResult, from: number, to: number, context: CompletionContext) => CompletionResult | null
+  /// Set a default set of [commit
+  /// characters](#autocomplete.Completion.commitCharacters) for all
+  /// options in this result.
+  commitCharacters?: readonly string[]
 }
 
 export class Option {

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,5 +1,5 @@
 import {EditorView} from "@codemirror/view"
-import {EditorState, StateEffect, Annotation, EditorSelection, TransactionSpec} from "@codemirror/state"
+import {EditorState, StateEffect, Annotation, EditorSelection, TransactionSpec, ChangeDesc} from "@codemirror/state"
 import {syntaxTree} from "@codemirror/language"
 import {SyntaxNode} from "@lezer/common"
 
@@ -232,6 +232,12 @@ export interface CompletionResult {
   /// [`validFor`](#autocomplete.CompletionResult.validFor)) that the
   /// completion still applies in the new state.
   update?: (current: CompletionResult, from: number, to: number, context: CompletionContext) => CompletionResult | null
+  /// When results contain position-dependent information in, for
+  /// example, `apply` methods, you can provide this method to update
+  /// the result for transactions that happen after the query. It is
+  /// not necessary to update `from` and `to`—those are tracked
+  /// automatically.
+  map?: (current: CompletionResult, changes: ChangeDesc) => CompletionResult | null
   /// Set a default set of [commit
   /// characters](#autocomplete.Completion.commitCharacters) for all
   /// options in this result.

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -96,7 +96,13 @@ export class CompletionContext {
     /// implicitly by typing. The usual way to respond to this is to
     /// only return completions when either there is part of a
     /// completable entity before the cursor, or `explicit` is true.
-    readonly explicit: boolean
+    readonly explicit: boolean,
+    /// The editor view. May be undefined if the context was created
+    /// in a situation where there is no such view available, such as
+    /// in synchronous updates via
+    /// [`CompletionResult.update`](#autocomplete.CompletionResult.update)
+    /// or when called by test code.
+    readonly view?: EditorView
   ) {}
 
   /// Get the extent, content, and (if there is a token) type of the

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,9 @@ export interface CompletionConfig {
   /// When enabled (defaults to true), autocompletion will start
   /// whenever the user types something that can be completed.
   activateOnTyping?: boolean
+  /// When given, if a completion that matches the predicate is
+  /// picked, reactivate completion again as if it was typed normally.
+  activateOnCompletion?: (completion: Completion) => boolean
   /// The amount of time to wait for further typing before querying
   /// completion sources via
   /// [`activateOnTyping`](#autocomplete.autocompletion^config.activateOnTyping).
@@ -93,6 +96,7 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
   combine(configs) {
     return combineConfig<Required<CompletionConfig>>(configs, {
       activateOnTyping: true,
+      activateOnCompletion: () => false,
       activateOnTypingDelay: 100,
       selectOnOpen: true,
       override: null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,11 @@ export interface CompletionConfig {
   /// match score. Defaults to using
   /// [`localeCompare`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare).
   compareCompletions?: (a: Completion, b: Completion) => number
+  /// When set to true (the default is false), turn off fuzzy matching
+  /// of completions and only show those that start with the text the
+  /// user typed. Only takes effect for results where
+  /// [`filter`](#autocomplete.CompletionResult.filter) isn't false.
+  filterStrict?: boolean
   /// By default, commands relating to an open completion only take
   /// effect 75 milliseconds after the completion opened, so that key
   /// presses made before the user is aware of the tooltip don't go to
@@ -100,6 +105,7 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
       icons: true,
       addToOptions: [],
       positionInfo: defaultPositionInfo as any,
+      filterStrict: false,
       compareCompletions: (a, b) => a.label.localeCompare(b.label),
       interactionDelay: 75,
       updateSyncTime: 100
@@ -109,7 +115,8 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
       icons: (a, b) => a && b,
       tooltipClass: (a, b) => c => joinClass(a(c), b(c)),
       optionClass: (a, b) => c => joinClass(a(c), b(c)),
-      addToOptions: (a, b) => a.concat(b)
+      addToOptions: (a, b) => a.concat(b),
+      filterStrict: (a, b) => a || b,
     })
   }
 })

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -43,7 +43,7 @@ export class FuzzyMatcher {
   ret(score: number, matched: readonly number[]) {
     this.score = score
     this.matched = matched
-    return true
+    return this
   }
 
   // Matches a given word (completion) against the pattern (input).
@@ -53,9 +53,9 @@ export class FuzzyMatcher {
   //
   // The score is a number that is more negative the worse the match
   // is. See `Penalty` above.
-  match(word: string): boolean {
+  match(word: string): {score: number, matched: readonly number[]} | null {
     if (this.pattern.length == 0) return this.ret(Penalty.NotFull, [])
-    if (word.length < this.pattern.length) return false
+    if (word.length < this.pattern.length) return null
     let {chars, folded, any, precise, byWord} = this
     // For single-character queries, only match when they occur right
     // at the start
@@ -64,7 +64,7 @@ export class FuzzyMatcher {
       let score = firstSize == word.length ? 0 : Penalty.NotFull
       if (first == chars[0]) {}
       else if (first == folded[0]) score += Penalty.CaseFold
-      else return false
+      else return null
       return this.ret(score, [0, firstSize])
     }
     let direct = word.indexOf(this.pattern)
@@ -78,7 +78,7 @@ export class FuzzyMatcher {
         i += codePointSize(next)
       }
       // No match, exit immediately
-      if (anyTo < len) return false
+      if (anyTo < len) return null
     }
 
     // This tracks the extent of the precise (non-folded, not
@@ -129,7 +129,7 @@ export class FuzzyMatcher {
     if (byWordTo == len)
       return this.result(Penalty.ByWord + (byWordFolded ? Penalty.CaseFold : 0) + Penalty.NotStart +
         (wordAdjacent ? 0 : Penalty.Gap), byWord, word)
-    return chars.length == 2 ? false
+    return chars.length == 2 ? null
       : this.result((any[0] ? Penalty.NotStart : 0) + Penalty.CaseFold + Penalty.Gap, any, word)
   }
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -143,3 +143,24 @@ export class FuzzyMatcher {
     return this.ret(score - word.length, result)
   }
 }
+
+
+export class StrictMatcher {
+  matched: readonly number[] = []
+  score: number = 0
+  folded: string
+
+  constructor(readonly pattern: string) {
+    this.folded = pattern.toLowerCase()
+  }
+
+  match(word: string): {score: number, matched: readonly number[]} | null {
+    if (word.length < this.pattern.length) return null
+    let start = word.slice(0, this.pattern.length)
+    let match = start == this.pattern ? 0 : start.toLowerCase() == this.folded ? Penalty.CaseFold : null
+    if (match == null) return null
+    this.matched = [0, start.length]
+    this.score = match + (word.length == this.pattern.length ? 0 : Penalty.NotFull)
+    return this
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import {keymap, KeyBinding} from "@codemirror/view"
 import {Completion, Option} from "./completion"
 import {completionState, State, setSelectedEffect} from "./state"
 import {CompletionConfig, completionConfig} from "./config"
-import {completionPlugin, moveCompletionSelection, acceptCompletion, startCompletion, closeCompletion} from "./view"
+import {completionPlugin, moveCompletionSelection, acceptCompletion,
+        startCompletion, closeCompletion, commitCharacters} from "./view"
 import {baseTheme} from "./theme"
 
 export {snippet, snippetCompletion, nextSnippetField, prevSnippetField,
@@ -17,6 +18,7 @@ export {CloseBracketConfig, closeBrackets, closeBracketsKeymap, deleteBracketPai
 /// Returns an extension that enables autocompletion.
 export function autocompletion(config: CompletionConfig = {}): Extension {
   return [
+    commitCharacters,
     completionState,
     completionConfig.of(config),
     completionPlugin,

--- a/src/snippet.ts
+++ b/src/snippet.ts
@@ -48,8 +48,9 @@ class Snippet {
     let fields: {seq: number | null, name: string}[] = []
     let lines = [], positions: FieldPos[] = [], m
     for (let line of template.split(/\r\n?|\n/)) {
-      while (m = /[#$]\{(?:(\d+)(?::([^}]*))?|([^}]*))\}/.exec(line)) {
-        let seq = m[1] ? +m[1] : null, name = m[2] || m[3] || "", found = -1
+      while (m = /[#$]\{(?:(\d+)(?::([^}]*))?|((?:\\[{}]|[^}])*))\}/.exec(line)) {
+        let seq = m[1] ? +m[1] : null, rawName = m[2] || m[3] || "", found = -1
+        let name = rawName.replace(/\\[{}]/g, m => m[1])
         for (let i = 0; i < fields.length; i++) {
           if (seq != null ? fields[i].seq == seq : name ? fields[i].name == name : false) found = i
         }
@@ -61,7 +62,7 @@ class Snippet {
           for (let pos of positions) if (pos.field >= found) pos.field++
         }
         positions.push(new FieldPos(found, lines.length, m.index, m.index + name.length))
-        line = line.slice(0, m.index) + name + line.slice(m.index + m[0].length)
+        line = line.slice(0, m.index) + rawName + line.slice(m.index + m[0].length)
       }
       line = line.replace(/\\([{}])/g, (_, brace, index) => {
         for (let pos of positions) if (pos.line == lines.length && pos.from > index) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -154,7 +154,7 @@ export class CompletionState {
 
   get tooltip(): Tooltip | null { return this.open ? this.open.tooltip : null }
 
-  get attrs() { return this.open ? this.open.attrs : baseAttrs }
+  get attrs() { return this.open ? this.open.attrs : this.active.length ? baseAttrs : noAttrs }
 }
 
 function sameResults(a: readonly ActiveSource[], b: readonly ActiveSource[]) {
@@ -171,6 +171,8 @@ function sameResults(a: readonly ActiveSource[], b: readonly ActiveSource[]) {
 const baseAttrs = {
   "aria-autocomplete": "list"
 }
+
+const noAttrs = {}
 
 function makeAttrs(id: string, selected: number) {
   let result: {[name: string]: string} = {

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,10 +35,10 @@ function sortOptions(active: readonly ActiveSource[], state: EditorState) {
         addOption(new Option(option, a.source, getMatch ? getMatch(option) : [], 1e9 - options.length))
       }
     } else {
-      let matcher = new FuzzyMatcher(state.sliceDoc(a.from, a.to))
-      for (let option of a.result.options) if (matcher.match(option.label)) {
-        let matched = !option.displayLabel ? matcher.matched : getMatch ? getMatch(option, matcher.matched) : []
-        addOption(new Option(option, a.source, matched, matcher.score + (option.boost || 0)))
+      let matcher = new FuzzyMatcher(state.sliceDoc(a.from, a.to)), match
+      for (let option of a.result.options) if (match = matcher.match(option.label)) {
+        let matched = !option.displayLabel ? match.matched : getMatch ? getMatch(option, match.matched) : []
+        addOption(new Option(option, a.source, matched, match.score + (option.boost || 0)))
       }
     }
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -186,7 +186,11 @@ const none: readonly any[] = []
 
 export const enum State { Inactive = 0, Pending = 1, Result = 2 }
 
-export function getUserEvent(tr: Transaction): "input" | "delete" | null {
+export function getUserEvent(tr: Transaction, conf: Required<CompletionConfig>): "input" | "delete" | null {
+  if (tr.isUserEvent("input.complete")) {
+    let completion = tr.annotation(pickedCompletion)
+    if (completion && conf.activateOnCompletion(completion)) return "input"
+  }
   return tr.isUserEvent("input.type") ? "input" : tr.isUserEvent("delete.backward") ? "delete" : null
 }
 
@@ -198,7 +202,7 @@ export class ActiveSource {
   hasResult(): this is ActiveResult { return false }
 
   update(tr: Transaction, conf: Required<CompletionConfig>): ActiveSource {
-    let event = getUserEvent(tr), value: ActiveSource = this
+    let event = getUserEvent(tr, conf), value: ActiveSource = this
     if (event)
       value = value.handleUserEvent(tr, event, conf)
     else if (tr.docChanged)

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -65,7 +65,8 @@ export const baseTheme = EditorView.baseTheme({
     padding: "3px 9px",
     width: "max-content",
     maxWidth: `${Info.Width}px`,
-    boxSizing: "border-box"
+    boxSizing: "border-box",
+    whiteSpace: "pre-line"
   },
 
   ".cm-completionInfo.cm-completionInfo-left": { right: "100%" },

--- a/src/view.ts
+++ b/src/view.ts
@@ -92,6 +92,7 @@ export const completionPlugin = ViewPlugin.fromClass(class implements PluginValu
     for (let i = 0; i < this.running.length; i++) {
       let query = this.running[i]
       if (doesReset ||
+          query.context.abortOnDocChange && update.docChanged ||
           query.updates.length + update.transactions.length > MaxUpdateCount && Date.now() - query.time > MinAbortTime) {
         for (let handler of query.context.abortListeners!) {
           try { handler() }

--- a/src/view.ts
+++ b/src/view.ts
@@ -130,7 +130,7 @@ export const completionPlugin = ViewPlugin.fromClass(class implements PluginValu
 
   startQuery(active: ActiveSource) {
     let {state} = this.view, pos = cur(state)
-    let context = new CompletionContext(state, pos, active.explicitPos == pos)
+    let context = new CompletionContext(state, pos, active.explicitPos == pos, this.view)
     let pending = new RunningQuery(active, context)
     this.running.push(pending)
     Promise.resolve(active.source(context)).then(result => {


### PR DESCRIPTION
Pulls in upstream changes from 6.12.0 → 6.18.0. 

There wasn't any merge conflicts to speak of, and the changes in the commits looks to be other areas of the code base than we have changed. I'll pull in the changes in the main repo and test it there.