### PR TITLE
Avoid re-arranging list of options when unfiltered results come in

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,8 @@ export interface CompletionConfig {
   /// displaying results from faster sources. Defaults to 100
   /// milliseconds.
   updateSyncTime?: number
+  /// overleaf: Move unfiltered results after the filtered ones
+  unfilteredResultsAtEnd?: boolean
 }
 
 export const completionConfig = Facet.define<CompletionConfig, Required<CompletionConfig>>({
@@ -112,7 +114,9 @@ export const completionConfig = Facet.define<CompletionConfig, Required<Completi
       filterStrict: false,
       compareCompletions: (a, b) => a.label.localeCompare(b.label),
       interactionDelay: 75,
-      updateSyncTime: 100
+      updateSyncTime: 100,
+      // overleaf: default to at top which is default CM6 behaviour
+      unfilteredResultsAtEnd: false
     }, {
       defaultKeymap: (a, b) => a && b,
       closeOnBlur: (a, b) => a && b,

--- a/src/state.ts
+++ b/src/state.ts
@@ -33,7 +33,8 @@ function sortOptions(active: readonly ActiveSource[], state: EditorState) {
     let getMatch = a.result.getMatch
     if (a.result.filter === false) {
       for (let option of a.result.options) {
-        addOption(new Option(option, a.source, getMatch ? getMatch(option) : [], 1e9 - options.length))
+        let defaultScore = conf.unfilteredResultsAtEnd ? -1e9 : 1e9
+        addOption(new Option(option, a.source, getMatch ? getMatch(option) : [], defaultScore - options.length))
       }
     } else {
       let pattern = state.sliceDoc(a.from, a.to), match


### PR DESCRIPTION
This PR avoid re-arranging the autocomplete menu in two situations:

1. The first commit adds a config option `unfilteredResultsAtEnd` that defaults to false, and matches the default CodeMirror behaviour:
  > When there are other sources, unfiltered completions appear at the top of the list of completions

The config option makes allows us to override that, and instead put them at the bottom. There's no right or wrong answer in general to this, since there's no general way of sorting filtered and unfiltered options, but in our case all of our unfiltered results come in asynchronously, so in order to not affect the order of the results already shown, it makes sense to put the new results at the end of the list.

2. Previously the deduplication would keep only the highest priority option from the list of results. This caused re-shuffling of the results when the ARS results were in a different order than the cite keys. In this PR we change the behaviour such that we keep the highest priority option, but at the highest scoring position. I've also moved this deduplication into the existing CM6 loop, to avoid two unnecessary iterations of the results array.